### PR TITLE
Fix code scanning alert no. 74: Incomplete string escaping or encoding

### DIFF
--- a/assets/js/training-courses.js
+++ b/assets/js/training-courses.js
@@ -184,7 +184,7 @@ $(document).ready(function () {
       const filterRegex = selectedGsLevels.map(gsLevel => {
         return selectedJobSeries.map(jobSeries => {
           return selectedCompetencies.map(competency => {
-            return `${competency.replace('*', '.*')} ${gsLevel.replace('*', '.*')} ${jobSeries.replace('*', '.*')}`;
+            return `${competency.replace(/\*/g, '.*')} ${gsLevel.replace(/\*/g, '.*')} ${jobSeries.replace(/\*/g, '.*')}`;
           });
         }).flat();
       }).flat().join('|');


### PR DESCRIPTION
Fixes [https://github.com/GSA/CFO.gov/security/code-scanning/74](https://github.com/GSA/CFO.gov/security/code-scanning/74)

To fix the problem, we need to ensure that all occurrences of the asterisk (`*`) in the `gsLevel`, `jobSeries`, and `competency` strings are replaced with `.*`. This can be achieved by using a regular expression with the global flag (`g`) in the `replace` method. This change will ensure that all asterisks are correctly replaced, resulting in the proper formation of the regular expression used for filtering the table.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
