### PR TITLE
Fix code scanning alert no. 53: Incomplete string escaping or encoding

### DIFF
--- a/_pages/coffa/assets/js/uswds.js
+++ b/_pages/coffa/assets/js/uswds.js
@@ -653,7 +653,8 @@ var trim = String.prototype.trim ? function (str) {
   return str.replace(RE_TRIM, '');
 };
 var queryById = function (id) {
-  return this.querySelector('[id="' + id.replace(/"/g, '\\"') + '"]');
+  id = id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return this.querySelector('[id="' + id + '"]');
 };
 module.exports = function resolveIds(ids, doc) {
   if (typeof ids !== 'string') {


### PR DESCRIPTION
Fixes [https://github.com/GSA/CFO.gov/security/code-scanning/53](https://github.com/GSA/CFO.gov/security/code-scanning/53)

To fix the problem, we need to ensure that all backslashes in the input string are properly escaped. This can be done by using a regular expression with the global flag to replace all occurrences of backslashes with double backslashes. This will ensure that any backslashes in the input are correctly escaped, preventing any potential injection attacks or other issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
