### PR TITLE
Fix code scanning alert no. 49: Client-side cross-site scripting

### DIFF
--- a/_pages/payment-accuracy/assets/js/search.js
+++ b/_pages/payment-accuracy/assets/js/search.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 document.addEventListener("DOMContentLoaded", function () {
     var searchResults = document.getElementById("search-results");
     var pathParts = window.location.pathname.split("/payment-accuracy/");
@@ -105,7 +107,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         pagerLinks +=
             '<span class="margin-2">Page ' +
-            page +
+            DOMPurify.sanitize(page) +
             " of " +
             Math.ceil(totalResults / resultsPerPage) +
             "</span>";

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "csv-writer": "^1.6.0",
     "jquery": "3.6.4",
     "react-redux": "^7.2.9",
-    "striptags": "^3.2.0"
+    "striptags": "^3.2.0",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "a11y": "^0.5.1",
@@ -22,7 +23,7 @@
   },
   "overrides": {
     "cross-spawn": "^6.0.6",
-    "trim":">=0.0.3",
+    "trim": ">=0.0.3",
     "tough-cookie": ">=4.1.4",
     "got": ">=11.8.5",
     "trim-newlines": ">=5.0.0"


### PR DESCRIPTION
Fixes [https://github.com/GSA/CFO.gov/security/code-scanning/49](https://github.com/GSA/CFO.gov/security/code-scanning/49)

To fix the problem, we need to ensure that any user-provided input is properly sanitized or escaped before being used in HTML content. In this case, we should escape the `page` parameter before inserting it into the DOM.

The best way to fix this issue is to use a library like `DOMPurify` to sanitize the user input. This library is well-known and widely used for preventing XSS attacks.

We will need to:
1. Import the `DOMPurify` library.
2. Use `DOMPurify` to sanitize the `page` parameter before using it in the HTML content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
