### PR TITLE
updating app.js to focus to top and change tabindex

### DIFF
--- a/_pages/coffa/assets/js/app.js
+++ b/_pages/coffa/assets/js/app.js
@@ -38,6 +38,9 @@ $('#return-top').on('click', function (e) {
     e.preventDefault();
     $([document.documentElement, document.body]).animate({
         scrollTop: 0
-    }, 200);
+    }, 200, function() {
+        document.body.setAttribute('tabindex', '-1');
+        document.body.focus();
+    });
     return false;
 });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -38,6 +38,9 @@ $('#return-top').on('click', function (e) {
     e.preventDefault();
     $([document.documentElement, document.body]).animate({
         scrollTop: 0
-    }, 200);
+    }, 200, function() {
+        document.body.setAttribute('tabindex', '-1');
+        document.body.focus();
+    });
     return false;
 });


### PR DESCRIPTION
COFFA - Clicking on "Return to top" link using TAB, focus will now go to the top and to skip to main content instead of going to the footer.

https://cg-4ade7cd3-a036-4fb7-b1d5-bcef64cb3ddf.sites.pages.cloud.gov/preview/gsa/cfo.gov/feature/OGPWEB-13003