### PR TITLE
Feature/ritm1294842

### DIFF
--- a/_includes/jfmip_latest_news.html
+++ b/_includes/jfmip_latest_news.html
@@ -1,2 +1,6 @@
-<p>Planning for the 2025 JFMIP Conference is underway! The 2025 JFMIP Conference will be held on March 18-19, 2025. Registration will be opening soon.</p>
-<p><a href="{{ site.baseurl }}/jfmip/events/">Click here for more information about past and upcoming JFMIP events</a>
+<!-- <p>Planning for the 2025 JFMIP Conference is underway! The 2025 JFMIP Conference will be held on March 18-19, 2025. Registration will be opening soon.</p>
+<p><a href="{{ site.baseurl }}/jfmip/events/">Click here for more information about past and upcoming JFMIP events</a> -->
+<p>The 2025 JFMIP Conference will be held on March 18-19, 2025. Registration is now open!</p>
+<p>Registration is free but is available exclusively to government employees (federal, state, local, or tribal) and their support contractors with current government contracts – you must register with an active '.gov', '.mil', or '.edu' email address to receive the Zoom information.</p>
+<p>Day 1 (March 18): <a href="https://events.zoomgov.com/ev/Atrw8bzvFWO9MsQZN49l994Jy0MV-4g-Z-Ew-D5Z_jZA7LccXZTU~ArrSTOoPNU3Rn5FDYoOSpW6Tnnkr0cgXBwkl48V0XMO_1GWKQrcELyD64w">Register via this link</a><br>Day 2 (March 19): <a href="https://events.zoomgov.com/ev/AmAx6hCdi6RdEXg36b2_NeBoUcii8F5d56njJIwjtnt4rcZs95Tw~Als6nwM9lAZ42xcByKwNYjUNRT9S6M6zKNNfkINqXkPKegvv3nCNruehEw">Register via this link</a></p>
+<p>Click <a href="https://www.cfo.gov/jfmip/events/">here</a> for more information about past and upcoming JFMIP events</p>

--- a/_pages/jfmip/events.html
+++ b/_pages/jfmip/events.html
@@ -10,7 +10,9 @@ title: Events
     </p>
     <p>Upcoming events:</p>
     <ul>
-        <li><b>March 18-19, 2025: 2025 JFMIP Conference. <a href="{{site.baseurl}}/assets/files/2025 JFMIP Conference Agenda.pdf">Draft 2025 JFMIP Conference Agenda</a>.</b> (More information coming soon!)</li>
+        <li><b>March 18-19, 2025: 2025 JFMIP Conference. <a href="{{site.baseurl}}/assets/files/2025 JFMIP Conference Agenda.pdf">Draft 2025 JFMIP Conference Agenda</a>.</b> The JFMIP conference is available exclusively to government employees (federal, state, local,) or tribal) and their support contractors with current government contracts – you must register with an active '.gov', '.mil', or '.edu' email address to receive the Zoom information. You need to register separately for both Day 1 and Day 2 if you want to attend the conference on both days.<br>
+            Day 1 (March 18): <a href="https://events.zoomgov.com/ev/Atrw8bzvFWO9MsQZN49l994Jy0MV-4g-Z-Ew-D5Z_jZA7LccXZTU~ArrSTOoPNU3Rn5FDYoOSpW6Tnnkr0cgXBwkl48V0XMO_1GWKQrcELyD64w">Register via this link</a><br>
+            Day 2 (March 19): <a href="https://events.zoomgov.com/ev/AmAx6hCdi6RdEXg36b2_NeBoUcii8F5d56njJIwjtnt4rcZs95Tw~Als6nwM9lAZ42xcByKwNYjUNRT9S6M6zKNNfkINqXkPKegvv3nCNruehEw">Register via this link</a>
     </ul>
     <p>Past events:</p>
     <ul>


### PR DESCRIPTION
Approved

[Preview](https://cg-4ade7cd3-a036-4fb7-b1d5-bcef64cb3ddf.sites.pages.cloud.gov/preview/gsa/cfo.gov/feature/RITM1294842/jfmip/events/)

Two webpage updates requested - picture attached for reference. Please reach out if there are any questions.

1. Every page of JFMIP Webpage: (https://www.cfo.gov/jfmip/, https://www.cfo.gov/jfmip/, https://www.cfo.gov/jfmip/initiatives/, https://www.cfo.gov/jfmip/events/, https://www.cfo.gov/jfmip/archive/, https://www.cfo.gov/jfmip/jfmip-awards/)

Please replace  text in banner:
Current text - "Latest News
Planning for the 2025 JFMIP Conference is underway! The 2025 JFMIP Conference will be held on March 18-19, 2025. Registration will be opening soon.
Click here for more information about past and upcoming JFMIP events"

New text - "Latest News
The 2025 JFMIP Conference will be held on March 18-19, 2025. Registration is now open!

Registration is free but is available exclusively to government employees (federal, state, local, or tribal) and their support contractors with current government contracts – you must register with an active '.gov', '.mil', or '.edu' email address to receive the Zoom information.

Day 1 (March 18): Register via this link (Hyperlink this link: https://events.zoomgov.com/ev/Atrw8bzvFWO9MsQZN49l994Jy0MV-4g-Z-Ew-D5Z_jZA7LccXZTU~ArrSTOoPNU3Rn5FDYoOSpW6Tnnkr0cgXBwkl48V0XMO_1GWKQrcELyD64w)
Day 2 (March 19): Register via this link (Hyperlink this link: https://events.zoomgov.com/ev/AmAx6hCdi6RdEXg36b2_NeBoUcii8F5d56njJIwjtnt4rcZs95Tw~Als6nwM9lAZ42xcByKwNYjUNRT9S6M6zKNNfkINqXkPKegvv3nCNruehEw)

Click here for more information about past and upcoming JFMIP events (Hyperlink this link: https://www.cfo.gov/jfmip/events/)




2. Updates to https://www.cfo.gov/jfmip/events/:
Replace text:

Current text - "Upcoming events:

March 18-19, 2025: 2025 JFMIP Conference. Draft 2025 JFMIP Conference Agenda. (More information coming soon!)"

New text - "Upcoming events
* March 18-19, 2025: 2025 JFMIP Conference. Draft 2025 JFMIP Conference Agenda (Hyperlink this link: https://www.cfo.gov/assets/files/2025%20JFMIP%20Conference%20Agenda.pdf). The JFMIP conference is available exclusively to government employees (federal, state, local,) or tribal) and their support contractors with current government contracts – you must register with an active '.gov', '.mil', or '.edu' email address to receive the Zoom information. You need to register separately for both Day 1 and Day 2 if you want to attend the conference on both days.
 
Day 1 (March 18): Register via this link (Hyperlink this link: https://events.zoomgov.com/ev/Atrw8bzvFWO9MsQZN49l994Jy0MV-4g-Z-Ew-D5Z_jZA7LccXZTU~ArrSTOoPNU3Rn5FDYoOSpW6Tnnkr0cgXBwkl48V0XMO_1GWKQrcELyD64w)
Day 2 (March 19): Register via this link (Hyperlink this link: https://events.zoomgov.com/ev/AmAx6hCdi6RdEXg36b2_NeBoUcii8F5d56njJIwjtnt4rcZs95Tw~Als6nwM9lAZ42xcByKwNYjUNRT9S6M6zKNNfkINqXkPKegvv3nCNruehEw)