### PR TITLE
Updated rack 2.2.10 -> 2.2.13 to fix vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.13)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)


### PR DESCRIPTION
Updated rack to latest version 2.2.13 to fix High vulnerability reported by Dependabot. [Preview Link](https://cg-4ade7cd3-a036-4fb7-b1d5-bcef64cb3ddf.sites.pages.cloud.gov/preview/gsa/cfo.gov/RITM1317779/)