### PR TITLE
Potential fix for code scanning alert no. 43: Client-side cross-site scripting

### DIFF
--- a/_pages/payment-accuracy/assets/js/search.js
+++ b/_pages/payment-accuracy/assets/js/search.js
@@ -1,4 +1,4 @@
-
+import DOMPurify from 'dompurify';
 document.addEventListener("DOMContentLoaded", function () {
     var searchResults = document.getElementById("search-results");
     var pathParts = window.location.pathname.split("/payment-accuracy/");

--- a/_pages/payment-accuracy/assets/js/search.js
+++ b/_pages/payment-accuracy/assets/js/search.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'dompurify';
+
 document.addEventListener("DOMContentLoaded", function () {
     var searchResults = document.getElementById("search-results");
     var pathParts = window.location.pathname.split("/payment-accuracy/");

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,4 +1,4 @@
-
+import DOMPurify from 'dompurify';
 document.addEventListener("DOMContentLoaded", function () {
 
     var searchResults = document.getElementById("search-results");
@@ -137,7 +137,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         pagerLinks += '<div class="usa-footer__contact-info grid-row grid-gap"><div class="grid-col-auto"><p class="margin-top-0">Powered by <strong>Search.gov</strong></p></div></div>';
         
-        pager.innerHTML = pagerLinks;
+        pager.innerHTML = DOMPurify.sanitize(pagerLinks);
     }
 
     function getLinkToPage(pageNumber) {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,4 +1,3 @@
-import DOMPurify from 'dompurify';
 document.addEventListener("DOMContentLoaded", function () {
 
     var searchResults = document.getElementById("search-results");


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/CFO.gov/security/code-scanning/43](https://github.com/GSA/CFO.gov/security/code-scanning/43)

To fix the issue, we need to sanitize or encode the user-provided input before inserting it into the DOM. Specifically:
1. Use a library like `DOMPurify` to sanitize the `pagerLinks` string before assigning it to `pager.innerHTML`. This ensures that any malicious input is neutralized.
2. Alternatively, use contextual escaping (e.g., `textContent` for text nodes or `setAttribute` for attributes) to avoid directly injecting HTML.

The best approach here is to sanitize the `pagerLinks` string using `DOMPurify` because it allows us to retain the intended HTML structure while removing any malicious content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
